### PR TITLE
adds Cart button to SingleProduct and creates useRouter shared function

### DIFF
--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -3,6 +3,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { fetchProduct } from "../store/singleProduct";
 import saveLocalCart from "../shared/saveLocalCart";
 import EmojiDisplay from "../shared/EmojiDisplay";
+import useRouter from "../shared/useRouter";
 
 /**
  * COMPONENT -- translating this from AllProducts
@@ -10,6 +11,7 @@ import EmojiDisplay from "../shared/EmojiDisplay";
 const SingleProduct = (props) => {
   const product = useSelector((reduxState) => reduxState.product);
   const dispatch = useDispatch();
+  const router = useRouter();
 
   // load the proper product when component mounts
   useEffect(() => {
@@ -27,6 +29,7 @@ const SingleProduct = (props) => {
           <div>
             <div>Price: ${parseFloat(product.price).toFixed(2)}</div>
             <button onClick={() => saveLocalCart(product)}>Add to cart</button>
+            <button onClick={(e) => router.push("/cart")}>View Cart</button>
           </div>
         </div>
       )}

--- a/client/shared/useRouter.js
+++ b/client/shared/useRouter.js
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+import {
+  useParams,
+  useLocation,
+  useHistory,
+  useRouteMatch,
+} from "react-router-dom";
+import queryString from "query-string";
+
+function useRouter() {
+  const params = useParams();
+  const location = useLocation();
+  const history = useHistory();
+  const match = useRouteMatch();
+
+  return useMemo(() => {
+    return {
+      push: history.push,
+      replace: history.replace,
+      pathname: location.pathname,
+      query: { ...queryString.parse(location.search), ...params },
+      match,
+      location,
+      history,
+    };
+  }, [params, match, location, history]);
+}
+
+export default useRouter;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jsonwebtoken": "^8.5.1",
     "morgan": "^1.9.1",
     "pg": "^8.5.1",
+    "query-string": "^7.1.1",
     "react-easy-emoji": "^1.8.0",
     "sequelize": "^6.3.5"
   },


### PR DESCRIPTION
Adds a 'View Cart' button to SingleProduct component which uses a custom useRouter function, also created in this PR.

The useRouter function combines built-in react-router-dom functions into one and I got the code/idea from here:
https://usehooks.com/useRouter/

The use case in this component is being able to add a button that pushes to a specific route super easily. I'm realizing after-the-fact I could have maybe just used history, but let's keep useRouter for now, in case it's useful down the line. I'll enter a task to potentially clean it up.